### PR TITLE
Disable wsl linter.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,6 +9,7 @@ linters-settings:
 linters:
   enable-all: true
   disable:
+    - wsl
     - stylecheck
     - gosec
     - dupl


### PR DESCRIPTION
This linter generates a large number of findings that are not useful.