### PR TITLE
find-badkey-certs: Directly get sha256(spki) instead of going through KeyDigest

### DIFF
--- a/cmd/find-badkey-certs/main.go
+++ b/cmd/find-badkey-certs/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/sha256"
 	"crypto/x509"
 	"database/sql"
 	"flag"
@@ -11,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/go-sql-driver/mysql"
-	"github.com/letsencrypt/boulder/core"
 	"github.com/letsencrypt/boulder/goodkey"
 )
 
@@ -160,10 +160,12 @@ func handleCert(id int64, serial string, der []byte, db dbQueryable, keyPolicy g
 		return err
 	}
 
-	hash, err := core.KeyDigest(cert.PublicKey)
+	keyDER, err := x509.MarshalPKIXPublicKey(cert.PublicKey)
 	if err != nil {
-		return nil
+		return err
 	}
+
+	hash := sha256.Sum256(keyDER)
 
 	fmt.Printf("%d %036x %x\n", id, cert.SerialNumber, hash)
 


### PR DESCRIPTION
The latter function base64 encodes the result, which ends up with us outputting a hex-encoded base64 encoding of the key digest, which is silly. Since KeyDigest isn't doing anything particularly useful for us (we don't care about JWKs), just do the equivalent thing directly and don't base64 encode at all.