### PR TITLE
stats-exporter: support exporting arbitrary dates

### DIFF
--- a/cmd/stats-exporter/main.go
+++ b/cmd/stats-exporter/main.go
@@ -139,16 +139,18 @@ func main() {
 	var latestDateStamp string
 	var outputFileName string
 	var err error
+	var now time.Time
+	var yesterday time.Time
 
 	if *latestFlag != "" {
 		// "now" is a misnomer, but it means the arbitrary date you've passed in
 		now, err = time.Parse("2006-01-02", *latestFlag)
-		yesterday := latestDate.Add(-24 * time.Hour)
+		yesterday = latestDate.Add(-24 * time.Hour)
 
 		cmd.FailOnError(err, "value of -latestdate could not be parsed as date")
 	} else {
-		now := time.Now()
-		yesterday := now.Add(-24 * time.Hour)
+		now = time.Now()
+		yesterday = now.Add(-24 * time.Hour)
 	}
 
 	earliestDateStamp = yesterday.Format("2006-01-02")

--- a/cmd/stats-exporter/main_test.go
+++ b/cmd/stats-exporter/main_test.go
@@ -277,7 +277,7 @@ func TestCompress(t *testing.T) {
 	outputFileName := "fakeFile.tsv"
 
 	checkedArgs := func(c *exec.Cmd) ([]byte, error) {
-		expected := "gzip fakeFile.tsv"
+		expected := "gzip -f fakeFile.tsv"
 		args := strings.Join(c.Args, " ")
 		if args != expected {
 			return nil, fmt.Errorf("wrong argument string. Got %q expected %q", args, expected)


### PR DESCRIPTION
Fixes #6

Also adds `gzip -f` flag to overwrite existing stats export if an SRE runs the command multiple times. Without `-f`, the script will error out.