### PR TITLE
Export results to the correct filename

### DIFF
--- a/cmd/stats-exporter/main.go
+++ b/cmd/stats-exporter/main.go
@@ -149,7 +149,9 @@ func main() {
 	earliestDateStamp := yesterday.Format("2006-01-02")
 	latestDateStamp := now.Format("2006-01-02")
 
-	outputFileName := fmt.Sprintf("results-%s.tsv", latestDateStamp)
+	// The stats-exporter gathers the previous days stats
+	// so we'll want to name the file based on that day
+	outputFileName := fmt.Sprintf("results-%s.tsv", earliestDateStamp)
 
 	outFile, err := os.OpenFile(outputFileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	cmd.FailOnError(err, fmt.Sprintf("Could not create results file %q", outputFileName))


### PR DESCRIPTION
Example of the current behavior that this commit will fix. The file should have been named `results-2020-09-02.tsv.gz` based on the data inside.

```
$ zcat /mnt/efs/results-2020-09-03.tsv.gz | head -n1
4289825882	com.starpromostudio.*	2020-09-02 00:00:00	038b240ad4a281f7dada58a898b7fdfed616

$ zcat /mnt/efs/results-2020-09-03.tsv.gz | tail -n1
4293562109	de.point-s.reifendimensionnord	2020-09-02 23:59:59	04abb32211bcd88d308fdc96da300cfe1eb0
```