### PR TITLE
s3-file-upload: Allow object ACL to be specified in YAML config

### DIFF
--- a/cmd/s3-file-upload/main.go
+++ b/cmd/s3-file-upload/main.go
@@ -43,6 +43,22 @@ func validateConf(conf Conf, configFilename string) (*Conf, error) {
 	if conf.BucketName == "" {
 		return nil, fmt.Errorf("required key: `bucket_name` is missing from file: %q", configFilename)
 	}
+
+	if conf.PutObjectACL != "" {
+		err := func() error {
+			var acl types.ObjectCannedACL
+			for _, value := range acl.Values() {
+				if string(value) == conf.PutObjectACL {
+					return nil
+				}
+			}
+			return fmt.Errorf("optional key: `put_object_acl` got: %q, from file: %q, expected one in: %s",
+				conf.PutObjectACL, configFilename, acl.Values())
+		}()
+		if err != nil {
+			return nil, err
+		}
+	}
 	return &conf, nil
 }
 

--- a/cmd/s3-file-upload/main.go
+++ b/cmd/s3-file-upload/main.go
@@ -13,16 +13,18 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"gopkg.in/yaml.v2"
 )
 
 // Config and it's fields are exported to receive the contents of a YAML
-// configuration file
+// configuration file.
 type Conf struct {
 	SecretAccessKey string `yaml:"secret_access_key"`
 	AccessKeyID     string `yaml:"access_key_id"`
 	Region          string `yaml:"region"`
 	BucketName      string `yaml:"bucket_name"`
+	PutObjectACL    string `yaml:"put_object_acl"`
 }
 
 func validateConf(conf Conf, configFilename string) (*Conf, error) {
@@ -102,6 +104,7 @@ func putFile(c *Conf, client *s3.Client, filename string) error {
 	input := &s3.PutObjectInput{
 		Bucket: aws.String(c.BucketName),
 		Key:    aws.String(filename),
+		ACL:    types.ObjectCannedACL(c.PutObjectACL),
 		Body:   file,
 	}
 	_, err = client.PutObject(context.Background(), input)

--- a/cmd/s3-file-upload/main_test.go
+++ b/cmd/s3-file-upload/main_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_validateConf(t *testing.T) {
+	type args struct {
+		conf           Conf
+		configFilename string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *Conf
+		wantErr bool
+	}{
+		// Happy paths.
+		{
+			"valid, no ACL",
+			args{Conf{"some_secret", "some_id", "some_region", "some_bucket", ""}, "some_file.yml"},
+			&Conf{"some_secret", "some_id", "some_region", "some_bucket", ""},
+			false,
+		},
+		{
+			"valid, with ACL",
+			args{Conf{"some_secret", "some_id", "some_region", "some_bucket", "bucket-owner-full-control"}, "some_file.yml"},
+			&Conf{"some_secret", "some_id", "some_region", "some_bucket", "bucket-owner-full-control"},
+			false,
+		},
+		// Sad paths.
+		{
+			"invalid, due to invalid ACL",
+			args{Conf{"some_secret", "some_id", "some_region", "some_bucket", "bucket-owner-medium-control"}, "some_file.yml"},
+			nil,
+			true,
+		},
+		{
+			"invalid, due to missing secret",
+			args{Conf{"", "some_id", "some_region", "some_bucket", ""}, "some_file.yml"},
+			nil,
+			true,
+		},
+		{
+			"invalid, due to missing id",
+			args{Conf{"some_secret", "", "some_region", "some_bucket", ""}, "some_file.yml"},
+			nil,
+			true,
+		},
+		{
+			"invalid, due to missing region",
+			args{Conf{"some_secret", "some_id", "", "some_bucket", ""}, "some_file.yml"},
+			nil,
+			true,
+		},
+		{
+			"invalid, due to missing bucket",
+			args{Conf{"some_secret", "some_id", "some_region", "", ""}, "some_file.yml"},
+			nil,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateConf(tt.args.conf, tt.args.configFilename)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateConf() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("validateConf() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add optional field `PutObjectACL` as key `put_object_acl` in the YAML config
file. This allows the operator to specify the ACL of objects pushed to S3
buckets using this tool.

[Valid ACLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl)